### PR TITLE
避免因为 bangumi-data 中番剧项中 sites 项缺少站点列表导致 ics 文件创建失败

### DIFF
--- a/src/default.json
+++ b/src/default.json
@@ -3,5 +3,6 @@
   "preferSites": ["bilibili", "iqiyi"],
   "maxOldBangumiMonth": 3,
   "epLength": 24,
+  "bangumiUrl":"https://bangumi.tv/",
   "dataUrl": "https://cdn.jsdelivr.net/npm/bangumi-data@0.3/dist/data.json"
 }

--- a/src/utils/data-processor.js
+++ b/src/utils/data-processor.js
@@ -5,6 +5,7 @@ const MAX_SEASON_EP_COUNT = DEFAULT.maxSeasonEpCount; // 默认每季集数.
 const MAX_OLD_BANGUMI_MONTH = DEFAULT.maxOldBangumiMonth; // 未结束老番最大月数
 const EP_LENGTH = DEFAULT.epLength; // 默认每集动画时长（分钟）
 const PREFER_SITES = DEFAULT.preferSites; // 默认偏好站点
+const BANGUMI_URL = DEFAULT.bangumiUrl; // 默认番剧 url
 
 const NO_ON_AIR_MSG = '无';
 const SITE_TYPE_ONAIR = 'onair';
@@ -65,7 +66,7 @@ const getBangumiDescription = siteList => {
 };
 
 const getBangumiUrl = siteList => {
-  if (siteList.length <= 0) return null;
+  if (siteList.length <= 0) return BANGUMI_URL; // 避免返回 null 导致 ics 创建失败
   PREFER_SITES.forEach(prefer => {
     const foundSite = siteList.find(site => site.site === prefer);
     if (foundSite) {

--- a/src/utils/data-processor.js
+++ b/src/utils/data-processor.js
@@ -8,6 +8,7 @@ const PREFER_SITES = DEFAULT.preferSites; // 默认偏好站点
 
 const NO_ON_AIR_MSG = '无';
 const SITE_TYPE_ONAIR = 'onair';
+const SITE_TYPE_INFO = 'info';
 
 
 const getInitialDateOfOldBangumi = (beginTime, timeNow) => {
@@ -41,7 +42,7 @@ const getBangumiSiteList = (bangumi, siteMeta) => {
         siteInfo.title &&
         siteInfo.urlTemplate &&
         siteInfo.type &&
-        siteInfo.type === SITE_TYPE_ONAIR
+        siteInfo.type === SITE_TYPE_ONAIR || SITE_TYPE_INFO // 避免没有 ONAIR 站点时 resultList 为空
       ) {
         resultList.push({
           site: site.site,


### PR DESCRIPTION
# 尝试解决的问题

在创建 ics 时，若 bangumi-data 中的数据项 sites 中只有 "bangumi" 或空时，会导致 ics 文件创建失败。
示例：
1. 只有 bangumi：
```json
  {
    "title": "【推しの子】",
    "titleTranslate": {
      "zh-Hans": [
        "【我推的孩子】"
      ]
    },
    "type": "tv",
    "lang": "ja",
    "officialSite": "https://ichigoproduction.com/",
    "begin": "2023-04-12T14:00:00.000Z",
    "broadcast": "R/2023-04-12T14:00:00.000Z/P7D",
    "end": "",
    "comment": "",
    "sites": [
      {
        "site": "bangumi",
        "id": "386809"
      }
    ]
  },
```
2. 空：
```json
  {
    "title": "スマーフ シーズン2",
    "titleTranslate": {
      "en": [
        "SMURFS"
      ]
    },
    "type": "tv",
    "lang": "ja",
    "officialSite": "https://www.nhk.jp/p/smurfs/ts/9YKXZ1954G/",
    "begin": "2023-04-05T10:00:00.000Z",
    "broadcast": "R/2023-04-05T10:00:00.000Z/P7D",
    "end": "",
    "comment": "",
    "sites": []
  }
```

报错内容:
```
  errors: [
    'url must be a `string` type, but the final value was: `null`.\n' +
      ' If "null" is intended as an empty value be sure to mark the schema as `.nullable()`'
  ],
```

# 尝试解决方法

1. 只有 bangumi 项的情况：修改了 data-processor.js 中的 getBangumiSiteList 方法，使类型为 info 的 site 也可以满足要求
2. 空的情况： default.json 加入了默认 url(https://bangumi.tv/)，并修改了 getBangumiUrl 方法使原本返回空的情况返回默认 url